### PR TITLE
Extract RPC settings into command-line/env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ The project is nowhere near usable. The code written so far is published for dev
 
 * Start up Bitcoin Core in regtest mode. Make sure the RPC server is enabled with `server=1` and that rpc username and password are set with `rpcuser=yourrpcusername` and `rpcpassword=yourrpcpassword` in the configuration file.
 
-* Download this git repository. Open the file `src/main.rs` and edit the RPC username and password in the function `get_bitcoin_rpc`. Make sure your Bitcoin Core has a wallet called `teleport`, or edit the name in the same function.
+* Configure RPC parameters by setting corresponding environment variables or command-line parameters.
+  >Set RPC URL, username and password by using `--rpc-url`, `--rpc-username` and `--rpc-password` command-line parameters
+  > or set corresponding environment variables (`RPC_URL`, `RPC_USERNAME` and `RPC_PASSWORD`) before running.
+
+* Make sure your Bitcoin Core has a wallet called `teleport`, or edit the name in the RPC URL parameter.
 
 * Create two teleport wallets by running `cargo run -- --wallet-file-name=<wallet-name> generate-wallet` twice. Instead of `<wallet-name>`, use something like `maker.teleport` and `taker.teleport`.
 


### PR DESCRIPTION
This PR removes hard-coded RPC parameters and makes them configurable via command line parameters or environment variables.

Updated CLI `help`:

```
teleport 0.1.0
A tool for CoinSwap

USAGE:
    teleport [OPTIONS] <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --rpc-password <rpc-password>            Node's RPC password [env: RPC_PASSWORD=]  [default: regtestrpcpass]
        --rpc-url <rpc-url>
            Node's RPC URL [env: RPC_URL=]  [default: http://localhost:18443/wallet/teleport]

        --rpc-username <rpc-username>            Node's RPC user name [env: RPC_USERNAME=]  [default: regtestrpcuser]
        --wallet-file-name <wallet-file-name>    Wallet file [default: wallet.teleport]

SUBCOMMANDS:
    coinswap-send          Runs Taker
    generate-wallet        Generates a new wallet file from a given seed phrase
    get-receive-invoice    Prints receive invoice
    help                   Prints this message or the help of the given subcommand(s)
    recover-wallet         Recovers a wallet file from a given seed phrase
    run-maker              Runs Maker server on provided port
    wallet-balance         Prints current wallet balance
```