### PR TITLE
use Script::new_p2pkh for creating P2PKH scriptPubKey

### DIFF
--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -24,7 +24,6 @@ use bitcoin::{
     },
     hashes::{
         hex::{FromHex, ToHex},
-        {hash160, Hash},
     },
     secp256k1,
     secp256k1::{Secp256k1, SecretKey, Signature},
@@ -648,13 +647,7 @@ impl Wallet {
 
                 let input_value =
                     convert_json_rpc_bitcoin_to_satoshis(&input_info["witness_utxo"]["amount"]);
-                let scriptcode = Builder::new()
-                    .push_opcode(all::OP_DUP)
-                    .push_opcode(all::OP_HASH160)
-                    .push_slice(&hash160::Hash::hash(pubkey.to_bytes().as_slice())[..])
-                    .push_opcode(all::OP_EQUALVERIFY)
-                    .push_opcode(all::OP_CHECKSIG)
-                    .into_script();
+                let scriptcode = Script::new_p2pkh(&pubkey.pubkey_hash());
                 let sighash = SigHashCache::new(&tx_clone).signature_hash(
                     ix,
                     &scriptcode,


### PR DESCRIPTION
This is a simple refactor PR that takes advantage of `Script::new_p2pkh()` from the bitcoin crate (see https://docs.rs/bitcoin/0.25.2/bitcoin/blockdata/script/struct.Script.html#method.new_p2pkh, avilable since 0.25.1) for creating a P2PKH output script rather than crafting it by hand. Also, for calculating the hash from the pubkey, it's `pubkey_hash()` method (https://docs.rs/bitcoin/0.25.2/bitcoin/util/key/struct.PublicKey.html#method.pubkey_hash -- available since 0.25.1) is used instead of `hashes::hash160`.

The implementation of `Script::new_p2pkh()` actually looks quite similar to what is replaced:
https://github.com/rust-bitcoin/rust-bitcoin/blob/b48f374c2cd6127aaa5e8b2ffbed80c3aa03245c/src/blockdata/script.rs#L238-L247

Note that I'm a total Rust noob, but at least the silent output of `cargo build` gives me some confidence that the change works 😎 