### PR TITLE
Added CI and Code Coverage toolings

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,44 @@
+on: [push, pull_request]
+
+name: Continuous Integration
+
+jobs:
+
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly 
+        features:
+          - default
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Set default toolchain
+        run: rustup default ${{ matrix.rust }}
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add clippy
+        run: rustup component add clippy
+      - name: Update toolchain
+        run: rustup update
+      - name: Build
+        run: cargo build --features ${{ matrix.features }} --no-default-features
+        # Uncomment clippy check after failures are removed
+      # - name: Clippy
+      #   run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
+      - name: Test
+        run: cargo test --features ${{ matrix.features }} --no-default-features

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,32 @@
+on: [push, pull_request]
+
+name: Code Coverage
+
+jobs:
+  Code-coverage:
+    name: Code coverage report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+
+      - name: Run cargo test
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+        run: cargo test
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
+        
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+
+on: [push, pull_request]
+
+name: Lint Checking
+
+jobs:
+
+  fmt:
+    name: Rust fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set default toolchain
+        run: rustup default stable
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add rustfmt
+        run: rustup component add rustfmt
+      - name: Update toolchain
+        run: rustup update
+      - name: Check fmt
+        run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,8 @@ rand = "0.7.3"
 itertools = "0.9.0"
 structopt = "0.3.21"
 dirs = "3.0.1"
+
+#Empty default feature set, (helpful to generalise in github actions)
+[features]
+default = [] 
+

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 100%
+        base: auto


### PR DESCRIPTION
This adds CI (build + test) using github action.

The tests in nightly build produces coverage report which can be displayed using codecov

Action for maintainer: 

- Sign up in codecov (https://about.codecov.io/)
- Install codecov extension in github. Add the repo reading permission (https://github.com/marketplace/codecov)
- Setup the codecov environment secret for actions to upload coverage report.

Rest is taken care of by the scripts.

This will create CI testing report as well as code coverage report for each PR.