### PR TITLE
Add logging level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bitcoin = "0.25"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.3", features = ["full"] }
+log = "^0.4"
 futures = "0.3"
 rand = "0.7.3"
 itertools = "0.9.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn generate_wallet(wallet_file_name: &PathBuf) -> std::io::Result<()> {
     let rpc = match get_bitcoin_rpc() {
         Ok(rpc) => rpc,
         Err(error) => {
-            println!("error connecting to bitcoin node: {:?}", error);
+            log::trace!(target: "main", "error connecting to bitcoin node: {:?}", error);
             return Ok(());
         }
     };
@@ -121,14 +121,14 @@ fn display_wallet_balance(wallet_file_name: &PathBuf, long_form: Option<bool>) {
     let mut wallet = match Wallet::load_wallet_from_file(wallet_file_name) {
         Ok(w) => w,
         Err(error) => {
-            println!("error loading wallet file: {:?}", error);
+            log::trace!(target: "main", "error loading wallet file: {:?}", error);
             return;
         }
     };
     let rpc = match get_bitcoin_rpc() {
         Ok(rpc) => rpc,
         Err(error) => {
-            println!("error connecting to bitcoin node: {:?}", error);
+            log::trace!(target: "main", "error connecting to bitcoin node: {:?}", error);
             return;
         }
     };
@@ -170,7 +170,7 @@ fn display_wallet_keys(wallet_file_name: &PathBuf) {
     let wallet = match Wallet::load_wallet_from_file(wallet_file_name) {
         Ok(w) => w,
         Err(error) => {
-            println!("error loading wallet file: {:?}", error);
+            log::trace!(target: "main", "error loading wallet file: {:?}", error);
             return;
         }
     };
@@ -181,14 +181,14 @@ fn print_receive_invoice(wallet_file_name: &PathBuf) {
     let mut wallet = match Wallet::load_wallet_from_file(wallet_file_name) {
         Ok(w) => w,
         Err(error) => {
-            println!("error loading wallet file: {:?}", error);
+            log::trace!(target: "main", "error loading wallet file: {:?}", error);
             return;
         }
     };
     let rpc = match get_bitcoin_rpc() {
         Ok(rpc) => rpc,
         Err(error) => {
-            println!("error connecting to bitcoin node: {:?}", error);
+            log::trace!(target: "main", "error connecting to bitcoin node: {:?}", error);
             return;
         }
     };
@@ -208,14 +208,14 @@ fn run_maker(wallet_file_name: &PathBuf, port: u16) {
     let rpc = match get_bitcoin_rpc() {
         Ok(rpc) => rpc,
         Err(error) => {
-            println!("error connecting to bitcoin node: {:?}", error);
+            log::trace!(target: "main", "error connecting to bitcoin node: {:?}", error);
             return;
         }
     };
     let mut wallet = match Wallet::load_wallet_from_file(wallet_file_name) {
         Ok(w) => w,
         Err(error) => {
-            println!("error loading wallet file: {:?}", error);
+            log::trace!(target: "main", "error loading wallet file: {:?}", error);
             return;
         }
     };
@@ -230,14 +230,14 @@ fn run_taker(wallet_file_name: &PathBuf) {
     let rpc = match get_bitcoin_rpc() {
         Ok(rpc) => rpc,
         Err(error) => {
-            println!("error connecting to bitcoin node: {:?}", error);
+            log::trace!(target: "main", "error connecting to bitcoin node: {:?}", error);
             return;
         }
     };
     let mut wallet = match Wallet::load_wallet_from_file(wallet_file_name) {
         Ok(w) => w,
         Err(error) => {
-            println!("error loading wallet file: {:?}", error);
+            log::trace!(target: "main", "error loading wallet file: {:?}", error);
             return;
         }
     };

--- a/src/offerbook_sync.rs
+++ b/src/offerbook_sync.rs
@@ -31,7 +31,7 @@ async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     let mut socket = match TcpStream::connect(host).await {
         Ok(s) => s,
         Err(_e) => {
-            println!("failed to connect to: {}", host);
+            log::trace!(target: "offer_book", "failed to connect to: {}", host);
             return None;
         }
     };
@@ -54,7 +54,7 @@ async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     let mut line1 = String::new();
     match socket_reader.read_line(&mut line1).await {
         Ok(0) | Err(_) => {
-            println!("failed to read line");
+            log::trace!(target: "offer_book", "failed to read line");
             return None;
         }
         Ok(_n) => (),
@@ -62,15 +62,15 @@ async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     let _makerhello = if let MakerToTakerMessage::MakerHello(m) = parse_message(&line1)? {
         m
     } else {
-        println!("wrong protocol message");
+        log::trace!(target: "offer_book", "wrong protocol message");
         return None;
     };
-    println!("maker hello = {:?}", _makerhello);
+    log::trace!(target: "offer_book", "maker hello = {:?}", _makerhello);
 
     let mut line2 = String::new();
     match socket_reader.read_line(&mut line2).await {
         Ok(0) | Err(_) => {
-            println!("failed to read line2");
+            log::trace!(target: "oofer_book", "failed to read line2");
             return None;
         }
         Ok(_n) => (),
@@ -78,7 +78,7 @@ async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     let offer = if let MakerToTakerMessage::Offer(o) = parse_message(&line2)? {
         o
     } else {
-        println!("wrong protocol message2");
+        log::trace!(target: "offer_book", "wrong protocol message2");
         return None;
     };
 

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -495,7 +495,7 @@ impl Wallet {
             return Ok(());
         }
 
-        println!("new wallet detected, synchronizing balance...");
+        log::trace!(target: "wallet", "new wallet detected, synchronizing balance...");
         self.import_initial_addresses(
             rpc,
             &hd_descriptors_to_import,
@@ -529,7 +529,7 @@ impl Wallet {
                     &[Value::String(rawtx_hex), Value::String(merkleproof)],
                 )?;
             } else {
-                println!("block pruned, TODO add UTXO to wallet file");
+                log::error!(target: "wallet", "block pruned, TODO add UTXO to wallet file");
                 panic!("teleport doesnt work with pruning yet, try rescanning");
             }
         }
@@ -616,7 +616,7 @@ impl Wallet {
         }
         let addr_type = path_chunks[1].parse::<u32>();
         if addr_type.is_err() {
-            println!("unexpected address_type = {}", path);
+            log::trace!(target: "wallet", "unexpected address_type = {}", path);
             return None;
         }
         let index = path_chunks[2].parse::<i32>();
@@ -823,7 +823,7 @@ impl Wallet {
             output_values.iter(),
             change_addresses.iter()
         ) {
-            println!("output_value = {} to addr={}", output_value, address);
+            log::trace!(target: "wallet", "output_value = {} to addr={}", output_value, address);
 
             let mut outputs = HashMap::<String, Amount>::new();
             outputs.insert(address.to_string(), Amount::from_sat(output_value));
@@ -886,7 +886,7 @@ impl Wallet {
             };
             self.sign_transaction(&mut spending_tx, &decoded_psbt);
 
-            println!(
+            log::trace!(target: "wallet",
                 "txhex = {}",
                 bitcoin::consensus::encode::serialize_hex(&spending_tx)
             );
@@ -1010,7 +1010,7 @@ impl Wallet {
             .iter()
             .map(|other_key| self.create_and_import_coinswap_address(rpc, other_key))
             .unzip();
-        println!("coinswap_addresses = {:#?}", coinswap_addresses);
+        log::trace!(target: "wallet", "coinswap_addresses = {:#?}", coinswap_addresses);
 
         let (my_funding_txes, utxo_indexes, funding_amounts) =
             self.create_spending_txes(rpc, total_coinswap_amount, &coinswap_addresses)?;


### PR DESCRIPTION
Update `println!`s to `log::trace`.  Fixes #20 

`log` seems like the lightest of all the crates available.

Changed `println`s to `log::trace` mostly. As it seems most errors and messages are to be displayed by default.

We might decide to add  other log levels later from different internal parts.   

Added target in logging as the module name generating the message. 

Kept few `println`s intact as they are used for user level communication.

