### PR TITLE
Remove warning about ECDSA verification

### DIFF
--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -438,10 +438,6 @@ fn verify_contract_tx_sig(
     pubkey: &PublicKey,
     sig: &Signature,
 ) -> bool {
-    //TODO possible exploit here if this code accepts high-S signatures
-    //but bitcoin doesnt
-    //similar https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26895
-
     let input_index = 0;
     let sighash = match Message::from_slice(
         &SigHashCache::new(contract_tx).signature_hash(


### PR DESCRIPTION
`rust-secp256k1` and the underlying `secp256k1` verify that high-S ECDSA signatures are rejected, effectively mitigating CVE-2020-26895 and similar vulnerabilities