### PR TITLE
dependencies: Remove duplicate bitcoin dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoincore-rpc = "0.12.0"
+bitcoincore-rpc = "0.13.0"
 #bitcoincore-rpc = {git="https://github.com/rust-bitcoin/rust-bitcoincore-rpc"}
 bitcoin-wallet = "1.1.0"
-bitcoin = "0.25"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.3", features = ["full"] }

--- a/src/contracts.rs
+++ b/src/contracts.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::array::TryFromSliceError;
 use std::convert::TryInto;
 
+use crate::bitcoin;
 use bitcoin::{
     blockdata::{
         opcodes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate bitcoin;
 extern crate bitcoin_wallet;
 extern crate bitcoincore_rpc;
 
@@ -12,6 +11,7 @@ use bitcoin::secp256k1::Secp256k1;
 use bitcoin::util::key::PublicKey;
 use bitcoin::Amount;
 use bitcoin_wallet::mnemonic;
+use bitcoincore_rpc::bitcoin;
 use bitcoincore_rpc::{Auth, Client, Error, RpcApi};
 
 use structopt::StructOpt;
@@ -378,7 +378,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod test {
-    use bitcoin::util::amount::Amount;
+    use super::bitcoin::util::amount::Amount;
     use serde_json::Value;
     use std::{thread, time};
     use tokio::io::AsyncWriteExt;

--- a/src/maker_protocol.rs
+++ b/src/maker_protocol.rs
@@ -12,6 +12,7 @@ use tokio::time::sleep;
 
 use serde_json::Value;
 
+use crate::bitcoin;
 use bitcoin::hashes::{hash160::Hash as Hash160, Hash};
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::{OutPoint, PublicKey, Transaction, TxOut};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::bitcoin;
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::util::key::PublicKey;
 use bitcoin::{Script, Transaction};

--- a/src/taker_protocol.rs
+++ b/src/taker_protocol.rs
@@ -8,6 +8,7 @@ use tokio::net::TcpStream;
 use tokio::prelude::*;
 use tokio::time::sleep;
 
+use crate::bitcoin;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::hashes::hash160::Hash as Hash160;
 use bitcoin::hashes::{hex::ToHex, Hash};

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -16,6 +16,7 @@ use itertools::izip;
 
 use bitcoin_wallet::mnemonic;
 
+use crate::bitcoin;
 use bitcoin::{
     blockdata::{
         opcodes::all,


### PR DESCRIPTION
Update `bitcoincore_rpc` dependency, remove direct dependency on `bitcoin`, and use `bitcoincore_rpc::bitcoin` as `bitcoin`

Resolves #18