### PR TITLE
Implement structure encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 bitcoincore-rpc = "0.12.0"
 #bitcoincore-rpc = {git="https://github.com/rust-bitcoin/rust-bitcoincore-rpc"}
 bitcoin-wallet = "1.1.0"
-bitcoin = "0.25"
+bitcoin = {version = "0.25", features = ["rand"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "0.3", features = ["full"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 
 use bitcoincore_rpc;
 
+use crate::serialization::NetSerializationError;
+
 // error enum for the whole project
 // try to make functions return this
 #[derive(Debug)]
@@ -11,11 +13,18 @@ pub enum Error {
     Disk(io::Error),
     Protocol(&'static str),
     Rpc(bitcoincore_rpc::Error),
+    Serialisation(NetSerializationError),
 }
 
 impl From<Box<dyn error::Error + Send>> for Error {
     fn from(e: Box<dyn error::Error + Send>) -> Error {
         Error::Network(e)
+    }
+}
+
+impl From<NetSerializationError> for Error {
+    fn from(e: NetSerializationError) -> Error {
+        Error::Serialisation(e)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ mod error;
 mod maker_protocol;
 mod messages;
 mod offerbook_sync;
+mod serialization;
 mod taker_protocol;
 
 fn generate_wallet(wallet_file_name: &PathBuf) -> std::io::Result<()> {
@@ -500,10 +501,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 mod test {
     use bitcoin::util::amount::Amount;
     use serde_json::Value;
-    use std::{thread, time};
-    use tokio::io::AsyncWriteExt;
-
     use std::str::FromStr;
+    use std::{thread, time};
+
+    use crate::messages::{TakerToMakerMessage, TestMessage};
 
     use super::*;
 
@@ -546,7 +547,12 @@ mod test {
             let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
             let (_, mut writer) = stream.split();
 
-            writer.write_all(b"kill").await.unwrap();
+            crate::taker_protocol::send_message(
+                &mut writer,
+                TakerToMakerMessage::TestMessage(TestMessage),
+            )
+            .await
+            .unwrap();
         }
         thread::sleep(time::Duration::from_secs(5));
     }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,10 +6,14 @@
 
 use serde::{Deserialize, Serialize};
 
+use bitcoin::consensus::{Decodable, Encodable};
 use bitcoin::hashes::hash160::Hash as Hash160;
+use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::util::key::PublicKey;
 use bitcoin::{Script, Transaction};
+
+use crate::serialization::{NetDeserilize, NetSerializationError, NetSerialize};
 
 pub const PREIMAGE_LEN: usize = 32;
 pub type Preimage = [u8; PREIMAGE_LEN];
@@ -19,16 +23,33 @@ pub type Preimage = [u8; PREIMAGE_LEN];
 //to distinguish them from structs which just collect together
 //data e.g. SenderContractTxInfo
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TakerHello {
     pub protocol_version_min: u32,
     pub protocol_version_max: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for TakerHello {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.protocol_version_min.consensus_encode(&mut w)?;
+        len += self.protocol_version_max.consensus_encode(&mut w)?;
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for TakerHello {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            protocol_version_min: u32::consensus_decode(&mut r)?,
+            protocol_version_max: u32::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GiveOffer;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SenderContractTxNoncesInfo {
     pub multisig_key_nonce: SecretKey,
     pub hashlock_key_nonce: SecretKey,
@@ -38,14 +59,60 @@ pub struct SenderContractTxNoncesInfo {
     pub funding_input_value: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SenderContractTxNoncesInfo {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.multisig_key_nonce.net_serialize(&mut w)?;
+        len += self.hashlock_key_nonce.net_serialize(&mut w)?;
+        len += self.timelock_pubkey.net_serialize(&mut w)?;
+        len += self.senders_contract_tx.consensus_encode(&mut w)?;
+        len += self.multisig_redeemscript.consensus_encode(&mut w)?;
+        len += self.funding_input_value.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SenderContractTxNoncesInfo {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            multisig_key_nonce: SecretKey::net_deserialize(&mut r)?,
+            hashlock_key_nonce: SecretKey::net_deserialize(&mut r)?,
+            timelock_pubkey: PublicKey::net_deserialize(&mut r)?,
+            senders_contract_tx: Transaction::consensus_decode(&mut r)?,
+            multisig_redeemscript: Script::net_deserialize(&mut r)?,
+            funding_input_value: u64::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SignSendersContractTx {
     pub txes_info: Vec<SenderContractTxNoncesInfo>,
     pub hashvalue: Hash160,
     pub locktime: u16,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SignSendersContractTx {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.txes_info.net_serialize(&mut w)?;
+        len += self.hashvalue.as_inner().net_serialize(&mut w)?;
+        len += self.locktime.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SignSendersContractTx {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            txes_info: Vec::<SenderContractTxNoncesInfo>::net_deserialize(&mut r)?,
+            hashvalue: Hash160::from_slice(&<[u8; 20]>::net_deserialize(&mut r)?)?,
+            locktime: u16::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ConfirmedCoinSwapTxInfo {
     pub funding_tx: Transaction,
     pub funding_tx_merkleproof: String,
@@ -55,55 +122,225 @@ pub struct ConfirmedCoinSwapTxInfo {
     pub hashlock_key_nonce: SecretKey,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for ConfirmedCoinSwapTxInfo {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.funding_tx.consensus_encode(&mut w)?;
+        len += self.funding_tx_merkleproof.consensus_encode(&mut w)?;
+        len += self.multisig_redeemscript.consensus_encode(&mut w)?;
+        len += self.multisig_key_nonce.net_serialize(&mut w)?;
+        len += self.contract_redeemscript.consensus_encode(&mut w)?;
+        len += self.hashlock_key_nonce.net_serialize(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for ConfirmedCoinSwapTxInfo {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            funding_tx: Transaction::consensus_decode(&mut r)?,
+            funding_tx_merkleproof: String::consensus_decode(&mut r)?,
+            multisig_redeemscript: Script::net_deserialize(&mut r)?,
+            multisig_key_nonce: SecretKey::net_deserialize(&mut r)?,
+            contract_redeemscript: Script::net_deserialize(&mut r)?,
+            hashlock_key_nonce: SecretKey::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct NextCoinSwapTxInfo {
     pub next_coinswap_multisig_pubkey: PublicKey,
     pub next_hashlock_pubkey: PublicKey,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for NextCoinSwapTxInfo {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.next_coinswap_multisig_pubkey.net_serialize(&mut w)?;
+        len += self.next_hashlock_pubkey.net_serialize(&mut w)?;
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for NextCoinSwapTxInfo {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            next_coinswap_multisig_pubkey: PublicKey::net_deserialize(&mut r)?,
+            next_hashlock_pubkey: PublicKey::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProofOfFunding {
     pub confirmed_funding_txes: Vec<ConfirmedCoinSwapTxInfo>,
     pub next_coinswap_info: Vec<NextCoinSwapTxInfo>,
     pub next_locktime: u16,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for ProofOfFunding {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.confirmed_funding_txes.net_serialize(&mut w)?;
+        len += self.next_coinswap_info.net_serialize(&mut w)?;
+        len += self.next_locktime.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for ProofOfFunding {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            confirmed_funding_txes: Vec::<ConfirmedCoinSwapTxInfo>::net_deserialize(&mut r)?,
+            next_coinswap_info: Vec::<NextCoinSwapTxInfo>::net_deserialize(&mut r)?,
+            next_locktime: u16::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendersAndReceiversContractSigs {
     pub receivers_sigs: Vec<Signature>,
     pub senders_sigs: Vec<Signature>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SendersAndReceiversContractSigs {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.receivers_sigs.net_serialize(&mut w)?;
+        len += self.senders_sigs.net_serialize(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SendersAndReceiversContractSigs {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            receivers_sigs: Vec::<Signature>::net_deserialize(&mut r)?,
+            senders_sigs: Vec::<Signature>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct ReceiversContractTxInfo {
     pub multisig_redeemscript: Script,
     pub contract_tx: Transaction,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for ReceiversContractTxInfo {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.multisig_redeemscript.consensus_encode(&mut w)?;
+        len += self.contract_tx.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for ReceiversContractTxInfo {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            multisig_redeemscript: Script::consensus_decode(&mut r)?,
+            contract_tx: Transaction::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SignReceiversContractTx {
     pub txes: Vec<ReceiversContractTxInfo>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SignReceiversContractTx {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        self.txes.net_serialize(&mut w)
+    }
+}
+
+impl NetDeserilize for SignReceiversContractTx {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            txes: Vec::<ReceiversContractTxInfo>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HashPreimage {
     pub senders_multisig_redeemscripts: Vec<Script>,
     pub receivers_multisig_redeemscripts: Vec<Script>,
     pub preimage: Preimage,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for HashPreimage {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.senders_multisig_redeemscripts.net_serialize(&mut w)?;
+        len += self
+            .receivers_multisig_redeemscripts
+            .net_serialize(&mut w)?;
+        len += self.preimage.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for HashPreimage {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            senders_multisig_redeemscripts: Vec::<Script>::net_deserialize(&mut r)?,
+            receivers_multisig_redeemscripts: Vec::<Script>::net_deserialize(&mut r)?,
+            preimage: <[u8; 32]>::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct SwapCoinPrivateKey {
     pub multisig_redeemscript: Script,
     pub key: SecretKey,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SwapCoinPrivateKey {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.multisig_redeemscript.net_serialize(&mut w)?;
+        len += self.key.net_serialize(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SwapCoinPrivateKey {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            multisig_redeemscript: Script::net_deserialize(&mut r)?,
+            key: SecretKey::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PrivateKeyHandover {
     pub swapcoin_private_keys: Vec<SwapCoinPrivateKey>, //could easily be called private_keys not swapcoin_private_keys
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for PrivateKeyHandover {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        self.swapcoin_private_keys.net_serialize(&mut w)
+    }
+}
+
+impl NetDeserilize for PrivateKeyHandover {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            swapcoin_private_keys: Vec::<SwapCoinPrivateKey>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TestMessage;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "method", rename_all = "lowercase")]
 pub enum TakerToMakerMessage {
     TakerHello(TakerHello),
@@ -114,15 +351,120 @@ pub enum TakerToMakerMessage {
     SignReceiversContractTx(SignReceiversContractTx),
     HashPreimage(HashPreimage),
     PrivateKeyHandover(PrivateKeyHandover),
+    TestMessage(TestMessage),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl TakerToMakerMessage {
+    fn to_flag(&self) -> u8 {
+        match self {
+            TakerToMakerMessage::TakerHello(_) => 1,
+            TakerToMakerMessage::GiveOffer(_) => 2,
+            TakerToMakerMessage::SignSendersContractTx(_) => 3,
+            TakerToMakerMessage::ProofOfFunding(_) => 4,
+            TakerToMakerMessage::SendersAndReceiversContractSigs(_) => 5,
+            TakerToMakerMessage::SignReceiversContractTx(_) => 6,
+            TakerToMakerMessage::HashPreimage(_) => 7,
+            TakerToMakerMessage::PrivateKeyHandover(_) => 8,
+            TakerToMakerMessage::TestMessage(_) => 9,
+        }
+    }
+}
+
+impl NetSerialize for TakerToMakerMessage {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.to_flag().consensus_encode(&mut w)?;
+
+        match self {
+            TakerToMakerMessage::TakerHello(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::GiveOffer(_) => Ok(len),
+            TakerToMakerMessage::SignSendersContractTx(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::ProofOfFunding(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::SendersAndReceiversContractSigs(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::SignReceiversContractTx(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::HashPreimage(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::PrivateKeyHandover(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            TakerToMakerMessage::TestMessage(_) => Ok(len),
+        }
+    }
+}
+
+impl NetDeserilize for TakerToMakerMessage {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let flag_byte = u8::consensus_decode(&mut r)?;
+
+        match flag_byte {
+            1 => Ok(Self::TakerHello(TakerHello::net_deserialize(&mut r)?)),
+            2 => Ok(Self::GiveOffer(GiveOffer)),
+            3 => Ok(Self::SignSendersContractTx(
+                SignSendersContractTx::net_deserialize(&mut r)?,
+            )),
+            4 => Ok(Self::ProofOfFunding(ProofOfFunding::net_deserialize(
+                &mut r,
+            )?)),
+            5 => Ok(Self::SendersAndReceiversContractSigs(
+                SendersAndReceiversContractSigs::net_deserialize(&mut r)?,
+            )),
+            6 => Ok(Self::SignReceiversContractTx(
+                SignReceiversContractTx::net_deserialize(&mut r)?,
+            )),
+            7 => Ok(Self::HashPreimage(HashPreimage::net_deserialize(&mut r)?)),
+            8 => Ok(Self::PrivateKeyHandover(
+                PrivateKeyHandover::net_deserialize(&mut r)?,
+            )),
+            9 => Ok(Self::TestMessage(TestMessage)),
+            _ => Err(NetSerializationError::General(
+                "unknown byte flag in message",
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MakerHello {
     pub protocol_version_min: u32,
     pub protocol_version_max: u32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+impl NetSerialize for MakerHello {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.protocol_version_min.consensus_encode(&mut w)?;
+        len += self.protocol_version_max.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for MakerHello {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            protocol_version_min: u32::consensus_decode(&mut r)?,
+            protocol_version_max: u32::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Offer {
     pub absolute_fee: u32,
     pub amount_relative_fee: f32,
@@ -131,12 +473,62 @@ pub struct Offer {
     pub tweakable_point: PublicKey,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for f32 {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        Ok(self.to_be_bytes().consensus_encode(&mut w)?)
+    }
+}
+
+impl NetDeserilize for f32 {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self::from_be_bytes(<[u8; 4]>::consensus_decode(&mut r)?))
+    }
+}
+
+impl NetSerialize for Offer {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.absolute_fee.consensus_encode(&mut w)?;
+        len += self.amount_relative_fee.net_serialize(&mut w)?;
+        len += self.max_size.consensus_encode(&mut w)?;
+        len += self.min_size.consensus_encode(&mut w)?;
+        len += self.tweakable_point.net_serialize(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for Offer {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            absolute_fee: u32::consensus_decode(&mut r)?,
+            amount_relative_fee: f32::net_deserialize(&mut r)?,
+            max_size: u64::consensus_decode(&mut r)?,
+            min_size: u64::consensus_decode(&mut r)?,
+            tweakable_point: PublicKey::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SendersContractSig {
     pub sigs: Vec<Signature>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SendersContractSig {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        self.sigs.net_serialize(&mut w)
+    }
+}
+
+impl NetDeserilize for SendersContractSig {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            sigs: Vec::<Signature>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct SenderContractTxInfo {
     pub contract_tx: Transaction,
     pub timelock_pubkey: PublicKey,
@@ -144,18 +536,72 @@ pub struct SenderContractTxInfo {
     pub funding_amount: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SenderContractTxInfo {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.contract_tx.consensus_encode(&mut w)?;
+        len += self.timelock_pubkey.net_serialize(&mut w)?;
+        len += self.multisig_redeemscript.net_serialize(&mut w)?;
+        len += self.funding_amount.consensus_encode(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SenderContractTxInfo {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            contract_tx: Transaction::consensus_decode(&mut r)?,
+            timelock_pubkey: PublicKey::net_deserialize(&mut r)?,
+            multisig_redeemscript: Script::net_deserialize(&mut r)?,
+            funding_amount: u64::consensus_decode(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct SignSendersAndReceiversContractTxes {
     pub receivers_contract_txes: Vec<Transaction>,
     pub senders_contract_txes_info: Vec<SenderContractTxInfo>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for SignSendersAndReceiversContractTxes {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.receivers_contract_txes.consensus_encode(&mut w)?;
+        len += self.senders_contract_txes_info.net_serialize(&mut w)?;
+
+        Ok(len)
+    }
+}
+
+impl NetDeserilize for SignSendersAndReceiversContractTxes {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            receivers_contract_txes: Vec::<Transaction>::consensus_decode(&mut r)?,
+            senders_contract_txes_info: Vec::<SenderContractTxInfo>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct ReceiversContractSig {
     pub sigs: Vec<Signature>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl NetSerialize for ReceiversContractSig {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        self.sigs.net_serialize(&mut w)
+    }
+}
+
+impl NetDeserilize for ReceiversContractSig {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self {
+            sigs: Vec::<Signature>::net_deserialize(&mut r)?,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "method", rename_all = "lowercase")]
 pub enum MakerToTakerMessage {
     MakerHello(MakerHello),
@@ -164,4 +610,276 @@ pub enum MakerToTakerMessage {
     SignSendersAndReceiversContractTxes(SignSendersAndReceiversContractTxes),
     ReceiversContractSig(ReceiversContractSig),
     PrivateKeyHandover(PrivateKeyHandover),
+}
+
+impl MakerToTakerMessage {
+    fn to_flag(&self) -> u8 {
+        match self {
+            MakerToTakerMessage::MakerHello(_) => 1,
+            MakerToTakerMessage::Offer(_) => 2,
+            MakerToTakerMessage::SendersContractSig(_) => 3,
+            MakerToTakerMessage::SignSendersAndReceiversContractTxes(_) => 4,
+            MakerToTakerMessage::ReceiversContractSig(_) => 5,
+            MakerToTakerMessage::PrivateKeyHandover(_) => 6,
+        }
+    }
+}
+
+impl NetSerialize for MakerToTakerMessage {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = self.to_flag().consensus_encode(&mut w)?;
+
+        match self {
+            MakerToTakerMessage::MakerHello(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            MakerToTakerMessage::Offer(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            MakerToTakerMessage::SendersContractSig(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            MakerToTakerMessage::SignSendersAndReceiversContractTxes(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            MakerToTakerMessage::ReceiversContractSig(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+            MakerToTakerMessage::PrivateKeyHandover(msg) => {
+                len += msg.net_serialize(&mut w)?;
+                Ok(len)
+            }
+        }
+    }
+}
+
+impl NetDeserilize for MakerToTakerMessage {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let flag = u8::consensus_decode(&mut r)?;
+
+        match flag {
+            1 => Ok(Self::MakerHello(MakerHello::net_deserialize(&mut r)?)),
+            2 => Ok(Self::Offer(Offer::net_deserialize(&mut r)?)),
+            3 => Ok(Self::SendersContractSig(
+                SendersContractSig::net_deserialize(&mut r)?,
+            )),
+            4 => Ok(Self::SignSendersAndReceiversContractTxes(
+                SignSendersAndReceiversContractTxes::net_deserialize(&mut r)?,
+            )),
+            5 => Ok(Self::ReceiversContractSig(
+                ReceiversContractSig::net_deserialize(&mut r)?,
+            )),
+            6 => Ok(Self::PrivateKeyHandover(
+                PrivateKeyHandover::net_deserialize(&mut r)?,
+            )),
+            _ => Err(NetSerializationError::General("unknown byte flag")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bitcoin::secp256k1::Secp256k1;
+    use bitcoin::secp256k1::{Message, SecretKey};
+
+    use bitcoin::secp256k1::rand::thread_rng;
+    use bitcoin::secp256k1::rand::RngCore;
+
+    use bitcoin::hashes::hex::FromHex;
+
+    use bitcoin::PrivateKey;
+
+    use crate::serialization::serialize;
+
+    use super::*;
+
+    fn test_tx() -> Transaction {
+        let tx_bytes = Vec::from_hex("0100000001a15d57094aa7a21a28cb20b59aab8fc7d1149a3bdbcddba9c622e4f5f6a99ece010000006c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52ffffffff0100e1f505000000001976a9140389035a9225b3839e2bbf32d826a1e222031fd888ac00000000").unwrap();
+        Transaction::consensus_decode(&tx_bytes[..]).unwrap()
+    }
+
+    fn test_script() -> Script {
+        let script_bytes = Vec::from_hex("6c493046022100f93bb0e7d8db7bd46e40132d1f8242026e045f03a0efe71bbb8e3f475e970d790221009337cd7f1f929f00cc6ff01f03729b069a7c21b59b1736ddfee5db5946c5da8c0121033b9b137ee87d5a812d6f506efdd37f0affa7ffc310711c06c7f3e097c9447c52").unwrap();
+        Script::net_deserialize(&script_bytes[..]).unwrap()
+    }
+
+    fn test_secret() -> SecretKey {
+        let mut bytes = [0u8; 32];
+        thread_rng().fill_bytes(&mut bytes);
+        SecretKey::from_slice(&bytes).unwrap()
+    }
+
+    fn test_pubkey() -> PublicKey {
+        let secret = test_secret();
+
+        PublicKey::from_private_key(
+            &Secp256k1::new(),
+            &PrivateKey {
+                compressed: true,
+                network: bitcoin::Network::Regtest,
+                key: secret,
+            },
+        )
+    }
+
+    fn test_sig() -> Signature {
+        let full = Secp256k1::new();
+        let (sk, _) = full.generate_keypair(&mut thread_rng());
+        let msg = Message::from_slice(&[2u8; 32]).unwrap();
+        full.sign(&msg, &sk)
+    }
+
+    fn test_proof_of_funding() -> ProofOfFunding {
+        let tx_info_msg = ConfirmedCoinSwapTxInfo {
+            funding_tx: test_tx(),
+            funding_tx_merkleproof: "Random String".to_string(),
+            multisig_redeemscript: test_script(),
+            multisig_key_nonce: test_secret(),
+            contract_redeemscript: test_script(),
+            hashlock_key_nonce: test_secret(),
+        };
+
+        let next_tx_info_msg = NextCoinSwapTxInfo {
+            next_coinswap_multisig_pubkey: test_pubkey(),
+            next_hashlock_pubkey: test_pubkey(),
+        };
+
+        ProofOfFunding {
+            confirmed_funding_txes: vec![tx_info_msg; 5],
+            next_coinswap_info: vec![next_tx_info_msg; 5],
+            next_locktime: 2784u16,
+        }
+    }
+
+    #[test]
+    fn test_taker_to_maker() {
+        let msg1 = TakerToMakerMessage::TakerHello(TakerHello {
+            protocol_version_min: 30,
+            protocol_version_max: 50,
+        });
+
+        let msg2 = TakerToMakerMessage::GiveOffer(GiveOffer);
+
+        let tx_nonce_info = SenderContractTxNoncesInfo {
+            multisig_key_nonce: test_secret(),
+            hashlock_key_nonce: test_secret(),
+            timelock_pubkey: test_pubkey(),
+            senders_contract_tx: test_tx(),
+            multisig_redeemscript: test_script(),
+            funding_input_value: 12345,
+        };
+
+        let mut hashvalue = [0u8; 20];
+        thread_rng().fill_bytes(&mut hashvalue);
+
+        let msg3 = TakerToMakerMessage::SignSendersContractTx(SignSendersContractTx {
+            txes_info: vec![tx_nonce_info; 5],
+            hashvalue: Hash160::from_slice(&hashvalue).unwrap(),
+            locktime: 3450,
+        });
+
+        let msg4 = TakerToMakerMessage::ProofOfFunding(test_proof_of_funding());
+
+        let sigs = SendersAndReceiversContractSigs {
+            receivers_sigs: vec![test_sig(); 10],
+            senders_sigs: vec![test_sig(); 10],
+        };
+
+        let msg5 = TakerToMakerMessage::SendersAndReceiversContractSigs(sigs);
+
+        let reciever_contract_tx_info = ReceiversContractTxInfo {
+            multisig_redeemscript: test_script().clone(),
+            contract_tx: test_tx().clone(),
+        };
+
+        let msg6 = TakerToMakerMessage::SignReceiversContractTx(SignReceiversContractTx {
+            txes: vec![reciever_contract_tx_info; 5],
+        });
+
+        let mut preimage = [0u8; 32];
+        thread_rng().fill_bytes(&mut preimage);
+
+        let msg7 = TakerToMakerMessage::HashPreimage(HashPreimage {
+            senders_multisig_redeemscripts: vec![test_script().clone(); 5],
+            receivers_multisig_redeemscripts: vec![test_script().clone(); 5],
+            preimage,
+        });
+
+        let swap_coin_privkey = SwapCoinPrivateKey {
+            multisig_redeemscript: test_script(),
+            key: test_secret(),
+        };
+
+        let msg8 = TakerToMakerMessage::PrivateKeyHandover(PrivateKeyHandover {
+            swapcoin_private_keys: vec![swap_coin_privkey.clone(); 5],
+        });
+
+        let msgs = vec![msg1, msg2, msg3, msg4, msg5, msg6, msg7, msg8];
+
+        let encoded = serialize(&msgs).unwrap();
+
+        let decoded = Vec::<TakerToMakerMessage>::net_deserialize(&encoded[..]).unwrap();
+
+        assert_eq!(decoded, msgs);
+    }
+
+    #[test]
+    fn test_maker_to_maker() {
+        let msg1 = MakerToTakerMessage::MakerHello(MakerHello {
+            protocol_version_min: 30,
+            protocol_version_max: 50,
+        });
+
+        let msg2 = MakerToTakerMessage::Offer(Offer {
+            absolute_fee: 1000,
+            amount_relative_fee: 54.678,
+            max_size: 567,
+            min_size: 123,
+            tweakable_point: test_pubkey(),
+        });
+
+        let msg3 = MakerToTakerMessage::SendersContractSig(SendersContractSig {
+            sigs: vec![test_sig(); 5],
+        });
+
+        let txinfo = SenderContractTxInfo {
+            contract_tx: test_tx(),
+            timelock_pubkey: test_pubkey(),
+            multisig_redeemscript: test_script(),
+            funding_amount: 100,
+        };
+
+        let msg4 = MakerToTakerMessage::SignSendersAndReceiversContractTxes(
+            SignSendersAndReceiversContractTxes {
+                receivers_contract_txes: vec![test_tx(); 5],
+                senders_contract_txes_info: vec![txinfo; 6],
+            },
+        );
+
+        let msg5 = MakerToTakerMessage::ReceiversContractSig(ReceiversContractSig {
+            sigs: vec![test_sig(); 10],
+        });
+
+        let swapcoin_privkeys = SwapCoinPrivateKey {
+            multisig_redeemscript: test_script(),
+            key: test_secret(),
+        };
+
+        let msg6 = MakerToTakerMessage::PrivateKeyHandover(PrivateKeyHandover {
+            swapcoin_private_keys: vec![swapcoin_privkeys; 5],
+        });
+
+        let messages = vec![msg1, msg2, msg3, msg4, msg5, msg6];
+
+        let encoded = serialize(&messages).unwrap();
+
+        let decoded = Vec::<MakerToTakerMessage>::net_deserialize(&encoded[..]).unwrap();
+
+        assert_eq!(decoded, messages);
+    }
 }

--- a/src/offerbook_sync.rs
+++ b/src/offerbook_sync.rs
@@ -1,9 +1,10 @@
 use tokio::io::BufReader;
 use tokio::net::TcpStream;
-use tokio::prelude::*;
 use tokio::sync::mpsc;
 
 use crate::messages::{GiveOffer, MakerToTakerMessage, Offer, TakerHello, TakerToMakerMessage};
+
+use crate::taker_protocol::{read_message, send_message};
 
 #[derive(Debug, Clone)]
 pub struct OfferAddress {
@@ -18,14 +19,6 @@ const MAKER_HOSTS: [&str; 4] = [
     "localhost:36102",
 ];
 
-fn parse_message(line: &str) -> Option<MakerToTakerMessage> {
-    let message: MakerToTakerMessage = match serde_json::from_str(line) {
-        Ok(r) => r,
-        Err(_e) => return None,
-    };
-    Some(message)
-}
-
 async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     //TODO add timeouts to deal with indefinite hangs
     let mut socket = match TcpStream::connect(host).await {
@@ -39,53 +32,35 @@ async fn download_maker_offer(host: &str) -> Option<OfferAddress> {
     let (socket_reader, mut socket_writer) = socket.split();
     let mut socket_reader = BufReader::new(socket_reader);
 
-    let mut message_packet = serde_json::to_vec(&TakerToMakerMessage::TakerHello(TakerHello {
-        protocol_version_min: 0,
+    let hello = TakerToMakerMessage::TakerHello(TakerHello {
         protocol_version_max: 0,
-    }))
-    .unwrap();
-    message_packet.push(b'\n');
-    message_packet
-        .append(&mut serde_json::to_vec(&TakerToMakerMessage::GiveOffer(GiveOffer)).unwrap());
-    message_packet.push(b'\n');
-    //TODO error handling here
-    socket_writer.write_all(&message_packet).await.unwrap();
+        protocol_version_min: 0,
+    });
 
-    let mut line1 = String::new();
-    match socket_reader.read_line(&mut line1).await {
-        Ok(0) | Err(_) => {
-            log::trace!(target: "offer_book", "failed to read line");
+    if let Err(_) = send_message(&mut socket_writer, hello).await {
+        log::trace!("Can't send Hello");
+    } else {
+        let give_offer = TakerToMakerMessage::GiveOffer(GiveOffer);
+        if let Err(_) = send_message(&mut socket_writer, give_offer).await {
+            log::trace!("Can't send offer request");
             return None;
         }
-        Ok(_n) => (),
-    };
-    let _makerhello = if let MakerToTakerMessage::MakerHello(m) = parse_message(&line1)? {
-        m
-    } else {
-        log::trace!(target: "offer_book", "wrong protocol message");
-        return None;
-    };
-    log::trace!(target: "offer_book", "maker hello = {:?}", _makerhello);
+    }
 
-    let mut line2 = String::new();
-    match socket_reader.read_line(&mut line2).await {
-        Ok(0) | Err(_) => {
-            log::trace!(target: "oofer_book", "failed to read line2");
+    if let Ok(MakerToTakerMessage::MakerHello(_)) = read_message(&mut socket_reader).await {
+        if let Ok(MakerToTakerMessage::Offer(offer)) = read_message(&mut socket_reader).await {
+            return Some(OfferAddress {
+                offer,
+                address: String::from(host),
+            });
+        } else {
+            log::trace!("Didn't recieve Offer");
             return None;
         }
-        Ok(_n) => (),
-    };
-    let offer = if let MakerToTakerMessage::Offer(o) = parse_message(&line2)? {
-        o
     } else {
-        log::trace!(target: "offer_book", "wrong protocol message2");
+        log::trace!("Didn't recieve Hello");
         return None;
-    };
-
-    Some(OfferAddress {
-        offer,
-        address: String::from(host),
-    })
+    }
 }
 
 pub async fn sync_offerbook() -> Vec<OfferAddress> {

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -1,0 +1,180 @@
+use bitcoin::consensus::encode::{Decodable, Encodable, ReadExt, WriteExt};
+use bitcoin::secp256k1::{SecretKey, Signature};
+use bitcoin::{PublicKey, Script, VarInt};
+
+// Maximum size, in bytes, of a vector we are allowed to decode
+// TODO: Decide whether its useful
+pub const MAX_VEC_SIZE: usize = 4_000_000;
+
+#[derive(Debug)]
+pub enum NetSerializationError {
+    IO(std::io::Error),
+
+    ConsensusEcode(bitcoin::consensus::encode::Error),
+
+    Secp256k1(bitcoin::secp256k1::Error),
+
+    Hash(bitcoin::hashes::Error),
+
+    Key(bitcoin::util::key::Error),
+
+    OverSizedAllocation { requested: usize, max: usize },
+
+    General(&'static str),
+}
+
+impl From<bitcoin::secp256k1::Error> for NetSerializationError {
+    fn from(e: bitcoin::secp256k1::Error) -> Self {
+        NetSerializationError::Secp256k1(e)
+    }
+}
+
+impl From<bitcoin::consensus::encode::Error> for NetSerializationError {
+    fn from(e: bitcoin::consensus::encode::Error) -> Self {
+        NetSerializationError::ConsensusEcode(e)
+    }
+}
+
+impl From<bitcoin::hashes::Error> for NetSerializationError {
+    fn from(e: bitcoin::hashes::Error) -> Self {
+        NetSerializationError::Hash(e)
+    }
+}
+
+impl From<std::io::Error> for NetSerializationError {
+    fn from(e: std::io::Error) -> Self {
+        NetSerializationError::IO(e)
+    }
+}
+
+impl From<bitcoin::util::key::Error> for NetSerializationError {
+    fn from(e: bitcoin::util::key::Error) -> Self {
+        NetSerializationError::Key(e)
+    }
+}
+
+// A Serializable Trait that defines byte encoding of structures
+// Anywhere we need byte encoded data (Network, Database) we can use this.
+// The underlying encoding of primitve datatyes and structures are done
+// via bitcoin::consensus::encode::Encodale trait.
+pub trait NetSerialize {
+    fn net_serialize<W: std::io::Write>(&self, w: W) -> Result<usize, NetSerializationError>;
+}
+
+pub trait NetDeserilize: Sized {
+    fn net_deserialize<R: std::io::Read>(r: R) -> Result<Self, NetSerializationError>;
+}
+
+// Implementation of Ser/Deserializable for some primitives not covered
+// by bitcoin::consensus::encode::Encodable
+impl NetSerialize for [u8; 20] {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        w.emit_slice(&self[..])?;
+        Ok(20)
+    }
+}
+
+impl NetDeserilize for [u8; 20] {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let mut bytes = [0u8; 20];
+        r.read_slice(&mut bytes)?;
+
+        Ok(bytes)
+    }
+}
+
+impl NetSerialize for Signature {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        Ok(w.write(&self.serialize_compact()[..])?)
+    }
+}
+
+impl NetDeserilize for Signature {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let mut sig_buff = [0u8; 64];
+        r.read_exact(&mut sig_buff)?;
+        Ok(Signature::from_compact(&sig_buff[..])?)
+    }
+}
+
+impl NetSerialize for SecretKey {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        Ok(w.write(&self[..])?)
+    }
+}
+
+impl NetDeserilize for SecretKey {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let mut secret_key_bytes = [0u8; 32];
+        r.read_slice(&mut secret_key_bytes)?;
+        Ok(SecretKey::from_slice(&secret_key_bytes)?)
+    }
+}
+
+impl NetSerialize for PublicKey {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        Ok(w.write(&self.to_bytes()[..])?)
+    }
+}
+
+impl NetDeserilize for PublicKey {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let mut bytes = [0u8; 33];
+        r.read_slice(&mut bytes)?;
+        Ok(PublicKey::from_slice(&bytes)?)
+    }
+}
+
+impl NetSerialize for Script {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        Ok(self.consensus_encode(&mut w)?)
+    }
+}
+
+impl NetDeserilize for Script {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        Ok(Self::consensus_decode(&mut r)?)
+    }
+}
+
+impl<T: NetSerialize> NetSerialize for Vec<T> {
+    fn net_serialize<W: std::io::Write>(&self, mut w: W) -> Result<usize, NetSerializationError> {
+        let mut len = 0;
+        len += VarInt(self.len() as u64).consensus_encode(&mut w)?;
+        for c in self.iter() {
+            len += c.net_serialize(&mut w)?;
+        }
+        Ok(len)
+    }
+}
+
+impl<T: NetDeserilize> NetDeserilize for Vec<T> {
+    fn net_deserialize<R: std::io::Read>(mut r: R) -> Result<Self, NetSerializationError> {
+        let len = VarInt::consensus_decode(&mut r)?.0;
+        let byte_size = (len as usize)
+            .checked_mul(std::mem::size_of::<T>())
+            .ok_or(NetSerializationError::General("Invalid length of vector"))?;
+        if byte_size > MAX_VEC_SIZE {
+            return Err(NetSerializationError::OverSizedAllocation {
+                requested: byte_size,
+                max: MAX_VEC_SIZE,
+            }
+            .into());
+        }
+        let mut ret = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            ret.push(NetDeserilize::net_deserialize(&mut r)?);
+        }
+        Ok(ret)
+    }
+}
+
+#[allow(dead_code)]
+// Helper function to quickly generate serialized data
+pub fn serialize<T: NetSerialize>(thing: &T) -> Result<Vec<u8>, NetSerializationError> {
+    let mut bytes = Vec::new();
+
+    thing.net_serialize(&mut bytes)?;
+
+    Ok(bytes)
+}


### PR DESCRIPTION
This PR implements our own Encoding/Decoding using `bitcoin::consensus::encode::Encodable` traits. 

I decided to go with our custom traits because that gives us flexibility and we need encoding for stuffs that isn't covered by rust-bitcoin (like `Signature`, `Publickey` etc).

The commits look bulky, but its mostly straight forward change.

Related #19 

There is a typo in function name `serialisable`, this is intentional to avoid conflict with `serde::serializable` and will be fixed once we move away from `serde` completely.   