### PR TITLE
Use Hash160 for strongly typed arguments

### DIFF
--- a/src/maker_protocol.rs
+++ b/src/maker_protocol.rs
@@ -603,7 +603,7 @@ fn handle_hash_preimage(
     wallet: Arc<RwLock<Wallet>>,
     message: HashPreimage,
 ) -> Result<Option<MakerToTakerMessage>, Error> {
-    let hashvalue = Hash160::hash(&message.preimage).into_inner();
+    let hashvalue = Hash160::hash(&message.preimage);
     {
         let mut wallet_mref = wallet.write().unwrap();
         for multisig_redeemscript in message.senders_multisig_redeemscripts {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use bitcoin::hashes::hash160::Hash as Hash160;
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::util::key::PublicKey;
 use bitcoin::{Script, Transaction};
@@ -37,7 +38,7 @@ pub struct SenderContractTxNoncesInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SignSendersContractTx {
     pub txes_info: Vec<SenderContractTxNoncesInfo>,
-    pub hashvalue: [u8; 20],
+    pub hashvalue: Hash160,
     pub locktime: u16,
 }
 

--- a/src/taker_protocol.rs
+++ b/src/taker_protocol.rs
@@ -70,7 +70,7 @@ async fn send_coinswap(
 
     let mut preimage = [0u8; 32];
     OsRng.fill_bytes(&mut preimage);
-    let hashvalue = Hash160::hash(&preimage).into_inner();
+    let hashvalue = Hash160::hash(&preimage);
 
     let first_swap_locktime = REFUND_LOCKTIME + REFUND_LOCKTIME_STEP * maker_count;
 
@@ -507,7 +507,7 @@ async fn request_senders_contract_tx_signatures<S: SwapCoin>(
     maker_multisig_nonces: &[SecretKey],
     maker_hashlock_nonces: &[SecretKey],
     timelock_pubkeys: &[PublicKey],
-    hashvalue: [u8; 20],
+    hashvalue: Hash160,
     locktime: u16,
 ) -> Result<Vec<Signature>, Error> {
     println!(
@@ -713,7 +713,7 @@ async fn send_proof_of_funding_and_get_contract_txes(
     next_peer_hashlock_pubkeys: &[PublicKey],
     maker_refund_locktime: u16,
     this_maker_contract_txes: &[Transaction],
-    hashvalue: [u8; 20],
+    hashvalue: Hash160,
 ) -> Result<(SignSendersAndReceiversContractTxes, Vec<Script>), Error> {
     send_message(
         socket_writer,


### PR DESCRIPTION
Use `bitcoin::hashes::hash160::Hash` in place of `[u8; 20]` for strongly typed arguments across the code base.