### PR TITLE
Fix incorrect Hash256 use for hash preimage

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,10 +6,13 @@
 
 use serde::{Deserialize, Serialize};
 
-use bitcoin::hashes::{hash160::Hash as Hash160, sha256::Hash as Hash256};
+use bitcoin::hashes::hash160::Hash as Hash160;
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::util::key::PublicKey;
 use bitcoin::{Script, Transaction};
+
+pub const PREIMAGE_LEN: usize = 32;
+pub type Preimage = [u8; PREIMAGE_LEN];
 
 //TODO the structs here which are actual messages should have the word Message
 //added to their name e.g. SignSendersContractTx
@@ -86,7 +89,7 @@ pub struct SignReceiversContractTx {
 pub struct HashPreimage {
     pub senders_multisig_redeemscripts: Vec<Script>,
     pub receivers_multisig_redeemscripts: Vec<Script>,
-    pub preimage: Hash256,
+    pub preimage: Preimage,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/taker_protocol.rs
+++ b/src/taker_protocol.rs
@@ -9,7 +9,7 @@ use tokio::prelude::*;
 use tokio::time::sleep;
 
 use bitcoin::consensus::encode::deserialize;
-use bitcoin::hashes::{hash160::Hash as Hash160, sha256::Hash as Hash256};
+use bitcoin::hashes::hash160::Hash as Hash160;
 use bitcoin::hashes::{hex::ToHex, Hash};
 use bitcoin::secp256k1::{SecretKey, Signature};
 use bitcoin::util::key::PublicKey;
@@ -30,7 +30,7 @@ use crate::contracts::{
 };
 use crate::error::Error;
 use crate::messages::{
-    ConfirmedCoinSwapTxInfo, HashPreimage, MakerToTakerMessage, NextCoinSwapTxInfo,
+    ConfirmedCoinSwapTxInfo, HashPreimage, MakerToTakerMessage, NextCoinSwapTxInfo, Preimage,
     PrivateKeyHandover, ProofOfFunding, ReceiversContractTxInfo, SenderContractTxNoncesInfo,
     SendersAndReceiversContractSigs, SignReceiversContractTx, SignSendersAndReceiversContractTxes,
     SignSendersContractTx, SwapCoinPrivateKey, TakerHello, TakerToMakerMessage,
@@ -73,7 +73,6 @@ async fn send_coinswap(
     let mut preimage = [0u8; 32];
     OsRng.fill_bytes(&mut preimage);
     let hashvalue = Hash160::hash(&preimage);
-    let preimage = Hash256::from_inner(preimage);
 
     let first_swap_locktime = REFUND_LOCKTIME + REFUND_LOCKTIME_STEP * maker_count;
 
@@ -909,7 +908,7 @@ fn create_incoming_swapcoins(
     next_peer_hashlock_keys_or_nonces: &[SecretKey],
     next_peer_multisig_pubkeys: &[PublicKey],
     next_peer_multisig_keys_or_nonces: &[SecretKey],
-    preimage: Hash256,
+    preimage: Preimage,
 ) -> Result<Vec<IncomingSwapCoin>, Error> {
     let next_swap_multisig_redeemscripts = maker_sign_sender_and_receiver_contracts
         .senders_contract_txes_info
@@ -1008,7 +1007,7 @@ async fn send_hash_preimage_and_get_private_keys(
     socket_writer: &mut WriteHalf<'_>,
     senders_multisig_redeemscripts: Vec<Script>,
     receivers_multisig_redeemscripts: Vec<Script>,
-    preimage: Hash256,
+    preimage: Preimage,
 ) -> Result<PrivateKeyHandover, Error> {
     let receivers_multisig_redeemscripts_len = receivers_multisig_redeemscripts.len();
     send_message(

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -24,7 +24,6 @@ use bitcoin::{
     hashes::{
         hash160::Hash as Hash160,
         hex::{FromHex, ToHex},
-        sha256::Hash as Hash256,
     },
     secp256k1,
     secp256k1::{Secp256k1, SecretKey, Signature},
@@ -52,6 +51,7 @@ use rand::RngCore;
 use crate::contracts;
 use crate::contracts::{read_hashvalue_from_contract, SwapCoin};
 use crate::error::Error;
+use crate::messages::Preimage;
 
 //these subroutines are coded so that as much as possible they keep all their
 //data in the bitcoin core wallet
@@ -106,7 +106,7 @@ pub struct IncomingSwapCoin {
     pub hashlock_privkey: SecretKey,
     pub funding_amount: u64,
     pub others_contract_sig: Option<Signature>,
-    pub hash_preimage: Option<Hash256>,
+    pub hash_preimage: Option<Preimage>,
 }
 
 //swapcoins are UTXOs + metadata which are not from the deterministic wallet
@@ -120,7 +120,7 @@ pub struct OutgoingSwapCoin {
     pub timelock_privkey: SecretKey,
     pub funding_amount: u64,
     pub others_contract_sig: Option<Signature>,
-    pub hash_preimage: Option<Hash256>,
+    pub hash_preimage: Option<Preimage>,
 }
 
 impl IncomingSwapCoin {


### PR DESCRIPTION
The hash preimage is not a SHA256 digest, and is replaced with a type alias for a 32-byte array

Resolves #34