### PR TITLE
Create low-R value signatures for improved privacy

### DIFF
--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -1464,9 +1464,9 @@ impl Wallet {
                         input_value,
                         SigHashType::All,
                     );
-                    //TODO use low-R value signatures for privacy
+                    //use low-R value signatures for privacy
                     //https://en.bitcoin.it/wiki/Privacy#Wallet_fingerprinting
-                    let signature = secp.sign(
+                    let signature = secp.sign_low_r(
                         &secp256k1::Message::from_slice(&sighash[..]).unwrap(),
                         &privkey.key,
                     );


### PR DESCRIPTION
The secp256k1 crate supports creating low-R signatures since v0.20.0 (https://docs.rs/secp256k1/0.20.0/secp256k1/struct.Secp256k1.html#method.sign_low_r), i.e. implementing this is as simple as changing the function call from `sign` to `sign_low_r` and we don't have to grind manually.