### PR TITLE
Fix generate-wallet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,9 @@ pub fn generate_wallet(wallet_file_name: &PathBuf) -> std::io::Result<()> {
         mnemonic::Mnemonic::new_random(bitcoin_wallet::account::MasterKeyEntropy::Sufficient)
             .unwrap();
 
+    Wallet::save_new_wallet_file(&wallet_file_name, mnemonic.to_string(), extension.clone())
+        .unwrap();
+
     let w = match Wallet::load_wallet_from_file(
         &wallet_file_name,
         network,
@@ -120,8 +123,9 @@ pub fn generate_wallet(wallet_file_name: &PathBuf) -> std::io::Result<()> {
         Ok(w) => w,
         Err(error) => panic!("error loading wallet file: {:?}", error),
     };
+
     println!("Importing addresses into Core. . .");
-    w.import_initial_addresses(
+    if let Err(e) = w.import_initial_addresses(
         &rpc,
         &w.get_hd_wallet_descriptors(&rpc)
             .unwrap()
@@ -129,11 +133,11 @@ pub fn generate_wallet(wallet_file_name: &PathBuf) -> std::io::Result<()> {
             .collect::<Vec<&String>>(),
         &Vec::<_>::new(),
         &Vec::<_>::new(),
-    )
-    .unwrap();
+    ) {
+        w.delete_wallet_file().unwrap();
+        panic!("error importing addresses: {:?}", e);
+    }
 
-    Wallet::save_new_wallet_file(&wallet_file_name, mnemonic.to_string(), extension.clone())
-        .unwrap();
     println!("Write down this seed phrase =\n{}", mnemonic.to_string());
     if !extension.trim().is_empty() {
         println!("And this extension =\n\"{}\"", extension);

--- a/src/wallet_sync.rs
+++ b/src/wallet_sync.rs
@@ -3,6 +3,7 @@
 // makers will only ever sync this way, but one day takers may sync in other
 // ways too such as a lightweight wallet method
 
+use std::fs;
 use std::fs::{File, OpenOptions};
 use std::io;
 use std::io::Read;
@@ -699,6 +700,10 @@ impl Wallet {
             timelocked_script_index_map: fidelity_bonds::generate_all_timelocked_addresses(&xprv),
         };
         Ok(wallet)
+    }
+
+    pub fn delete_wallet_file(&self) -> Result<(), Error> {
+        Ok(fs::remove_file(&self.wallet_file_name)?)
     }
 
     pub fn update_external_index(&mut self, new_external_index: u32) -> Result<(), Error> {


### PR DESCRIPTION
Currently `generate_wallet` fails at `Wallet::load_wallet_from_file()` since the file is not created until further down. To get around the issue with Bitcoin Core not having a wallet named "teleport" we can delete the wallet file when importing addresses fails.